### PR TITLE
Add a way of overriding environment baseURL per request

### DIFF
--- a/Sources/Chimney/Chimney.swift
+++ b/Sources/Chimney/Chimney.swift
@@ -157,7 +157,7 @@ extension Requestable {
 extension PathComponentsProvider {
     /// If a request path has the base URL as first path component, set that as the base URL for the request and remove it from path components
     func baseURLAndPathComponents() -> (String?, [String]) {
-        if let firstPathComponent = pathComponents.path.first, firstPathComponent.contains("https://") {
+        if let firstPathComponent = pathComponents.path.first, firstPathComponent.contains("https://") || firstPathComponent.contains("http://") {
             var components = pathComponents.path
             components.removeFirst()
             return (firstPathComponent, components)

--- a/Sources/Chimney/Chimney.swift
+++ b/Sources/Chimney/Chimney.swift
@@ -154,29 +154,17 @@ extension Requestable {
         return config
     }
 }
-extension PathComponentsProvider {
-    /// If a request path has the base URL as first path component, set that as the base URL for the request and remove it from path components
-    func baseURLAndPathComponents() -> (String?, [String]) {
-        if let firstPathComponent = pathComponents.path.first, firstPathComponent.contains("https://") || firstPathComponent.contains("http://") {
-            var components = pathComponents.path
-            components.removeFirst()
-            return (firstPathComponent, components)
-        }
-        return (environment.configuration?.baseURL.absoluteString, pathComponents.path)
-    }
-}
+
 
 extension Requestable {
     internal static func requestData(path: Path, parameters: Parameter?, sessionConfig: URLSessionConfiguration? = nil, completion: @escaping ((Result<Data, RequestableError>) -> Void)) {
 
         let (foundBaseURL, pathComponents) = path.baseURLAndPathComponents()
-        
         guard let baseURL = foundBaseURL else {
             print("No base URL set or given")
             return
         }
-        
-        
+
         let auth: [String: String]?
         var urlComponents: URLComponents
 
@@ -237,6 +225,18 @@ extension Requestable {
             } catch {
                 completion(.failure(.underlying(error: error)))
             }
+    }
+}
+
+extension PathComponentsProvider {
+    /// If a request path has the base URL as first path component, set that as the base URL for the request and remove it from path components
+    func baseURLAndPathComponents() -> (String?, [String]) {
+        if let firstPathComponent = pathComponents.path.first, firstPathComponent.contains("https://") || firstPathComponent.contains("http://") {
+            var components = pathComponents.path
+            components.removeFirst()
+            return (firstPathComponent, components)
+        }
+        return (environment.configuration?.baseURL.absoluteString, pathComponents.path)
     }
 }
 

--- a/Sources/Chimney/Chimney.swift
+++ b/Sources/Chimney/Chimney.swift
@@ -157,10 +157,19 @@ extension Requestable {
 
 extension Requestable {
     internal static func requestData(path: Path, parameters: Parameter?, sessionConfig: URLSessionConfiguration? = nil, completion: @escaping ((Result<Data, RequestableError>) -> Void)) {
-        guard let baseURL = environment.configuration?.baseURL.absoluteString else {
-            print("No baseURL set!")
+        
+        let foundBaseURL: String? = {
+            if let firstPathComponent = path.pathComponents.path.first, firstPathComponent.contains("https://") {
+                return firstPathComponent
+            } else {
+                return environment.configuration?.baseURL.absoluteString
+            }
+        }()
+        guard let baseURL = foundBaseURL else {
+            print("No base URL set or given")
             return
         }
+        
         
         let auth: [String: String]?
         var urlComponents: URLComponents

--- a/Tests/ChimneyTests/ChimneyTests.swift
+++ b/Tests/ChimneyTests/ChimneyTests.swift
@@ -46,7 +46,26 @@ final class ChimneyTests: XCTestCase {
         waitForExpectations(timeout: 31, handler: nil)
     }
     
+    func testGetRequestWithBaseURLInPathComponents() {
+        let exp = expectation(description: "do a simple GET request")
+        let wantedResult = Todo.init(id: 1, userId: 1, title: "delectus aut autem", completed: false)
+        /// Sets the "wrong baseURL" so we can test that this is not used
+        Chimney.environment = Environment.init(configuration: Configuration.init(basicHTTPAuth: nil, baseURL: URL.init(string: "https://notAWorkingDomain.no")!))
+        
+        GetTodosWithBaseURLInPathRequestable.request(path: .init(index: 1)) { result in
+            switch result {
+                case .failure(let error):
+                    XCTFail(error.debugDescription)
+                case .success(let success):
+                    XCTAssertEqual(success, wantedResult)
+            }
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
     static var allTests = [
+        ("testGetRequestWithBaseURLInPathComponents", testGetRequestWithBaseURLInPathComponents),
         ("testSimpleGetRequest", testSimpleGetRequest),
         ("testWrongPathTimeout", testWrongPathTimeout)
     ]

--- a/Tests/ChimneyTests/ExampleRequests.swift
+++ b/Tests/ChimneyTests/ExampleRequests.swift
@@ -65,3 +65,29 @@ public enum GetWrongPathTodosRequestable: Requestable {
         }
     }
 }
+
+
+public enum GetTodosWithBaseURLInPathRequestable: Requestable {
+    public typealias Parameter = Never
+    public typealias Response = Todo
+    
+    public static let method: HTTPMethod = .get
+    
+    public struct Path: PathComponentsProvider {
+        public typealias Query = Never
+       
+        public let index: Int
+        
+        public init(index: Int) {
+          
+            self.index = index
+        }
+        
+        public var pathComponents: (path: [String], query: Query?) {
+            return (
+                ["https://jsonplaceholder.typicode.com","todos", "\(self.index)"],
+                nil
+            )
+        }
+    }
+}


### PR DESCRIPTION
With giving a valid URL in the first path component in a request, the api should use that baseURL instead of the enviroment baseURL 